### PR TITLE
Refactor to modular components

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
-import * as THREE from 'three'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { useRef, useState } from 'react'
 import './App.css'
+import ThreeScene from './components/ThreeScene.jsx'
+import CameraPlaylist from './components/CameraPlaylist.jsx'
+import Controls from './components/Controls.jsx'
+import Toasts from './components/Toasts.jsx'
+import { tweenTo } from './utils/tween.js'
 
 /**
  * Developer Guide
@@ -15,15 +17,12 @@ import './App.css'
  *   4. `npm run build` - build the production bundle.
  *
  * Overview
- *   - This component mounts a three.js scene that loads `public/Chicken.glb` and
- *     plays its animation in a loop.
+ *   - This component coordinates the three.js scene and UI controls.
  *   - The UI lets you drag preset camera angles into a playlist and play them
  *     back sequentially. "Play Sound" starts a simple Web Audio melody.
  */
 
 function App() {
-  // Refs keep track of three.js objects and audio nodes
-  const mountRef = useRef(null)
   const cameraRef = useRef(null)
   const controlsRef = useRef(null)
   const audioCtxRef = useRef(null)
@@ -31,65 +30,10 @@ function App() {
   const noteIntervalRef = useRef(null)
   const [audioOn, setAudioOn] = useState(false)
   const [playing, setPlaying] = useState(false)
-  // Playlist holds camera positions dragged in by the user
   const [playlist, setPlaylist] = useState(Array(20).fill(null))
   const [currentStep, setCurrentStep] = useState(0)
-  // Array of toast notifications to display in the UI
   const [toasts, setToasts] = useState([])
 
-  // Set up the three.js scene once on mount
-  useEffect(() => {
-    const mount = mountRef.current
-    const width = mount.clientWidth
-    const height = mount.clientHeight
-
-    const scene = new THREE.Scene()
-    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000)
-    camera.position.set(0, 1.5, 5)
-    cameraRef.current = camera
-
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
-    renderer.setSize(width, height)
-    mount.appendChild(renderer.domElement)
-
-    const controls = new OrbitControls(camera, renderer.domElement)
-    controls.enableDamping = true
-    controlsRef.current = controls
-
-    const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1)
-    scene.add(light)
-
-    const loader = new GLTFLoader()
-    let mixer
-
-    loader.load('/Chicken.glb', (gltf) => {
-      const model = gltf.scene
-      scene.add(model)
-
-      if (gltf.animations && gltf.animations.length) {
-        mixer = new THREE.AnimationMixer(model)
-        const action = mixer.clipAction(gltf.animations[0])
-        action.play()
-      }
-      animate()
-    })
-
-    const clock = new THREE.Clock()
-
-    function animate() {
-      requestAnimationFrame(animate)
-      if (mixer) mixer.update(clock.getDelta())
-      controls.update()
-      renderer.render(scene, camera)
-    }
-
-    return () => {
-      renderer.dispose()
-      mount.removeChild(renderer.domElement)
-    }
-  }, [])
-
-  // Predefined camera locations referenced by the playlist
   const angles = {
     front: { x: 0, y: 1.5, z: 5 },
     back: { x: 0, y: 1.5, z: -5 },
@@ -98,8 +42,6 @@ function App() {
     top: { x: 0, y: 5, z: 0 },
   }
 
-
-  // Start or stop the Web Audio oscillator that plays a short melody
   function toggleAudio() {
     if (audioOn) {
       clearInterval(noteIntervalRef.current)
@@ -131,37 +73,6 @@ function App() {
     setAudioOn(true)
   }
 
-
-  // Smoothly move the camera to `pos` over `duration` milliseconds
-  function tweenTo(pos, duration = 1000) {
-    return new Promise((resolve) => {
-      if (!cameraRef.current || !controlsRef.current) {
-        resolve()
-        return
-      }
-      const camera = cameraRef.current
-      const controls = controlsRef.current
-      const start = camera.position.clone()
-      const target = new THREE.Vector3(pos.x, pos.y, pos.z)
-      let startTime
-      function step(time) {
-        if (!startTime) startTime = time
-        const t = (time - startTime) / duration
-        if (t < 1) {
-          camera.position.lerpVectors(start, target, t)
-          controls.update()
-          requestAnimationFrame(step)
-        } else {
-          camera.position.copy(target)
-          controls.update()
-          resolve()
-        }
-      }
-      requestAnimationFrame(step)
-    })
-  }
-
-  // Show a short toast notification on screen
   function addToast(message) {
     const id = Date.now()
     setToasts((t) => [...t, { id, message }])
@@ -170,7 +81,6 @@ function App() {
     }, 2000)
   }
 
-  // Drop handler for placing a camera angle into the playlist
   function handleDrop(e, index) {
     e.preventDefault()
     const name = e.dataTransfer.getData('text/plain')
@@ -183,12 +93,10 @@ function App() {
     addToast(`${name} set in slot ${index + 1}`)
   }
 
-  // Start dragging a camera angle from the preset list
   function handleDragStart(e, name) {
     e.dataTransfer.setData('text/plain', name)
   }
 
-  // Tween the camera through each active playlist entry
   async function playPlaylist() {
     if (playing) return
     setPlaying(true)
@@ -198,7 +106,7 @@ function App() {
       const { pos, name } = active[i]
       addToast(`Moving to ${name}`)
       setCurrentStep(i)
-      await tweenTo(pos, 2000)
+      await tweenTo(cameraRef.current, controlsRef.current, pos, 2000)
     }
     setCurrentStep(active.length)
     setPlaying(false)
@@ -208,68 +116,24 @@ function App() {
 
   return (
     <div className="flex h-full relative">
-      <div className="w-64 p-2 bg-white bg-opacity-70 overflow-y-auto space-y-2">
-        <h2 className="font-bold">Camera Angles</h2>
-        <div className="space-y-1">
-          {Object.keys(angles).map((name) => (
-            <div
-              key={name}
-              draggable
-              onDragStart={(e) => handleDragStart(e, name)}
-              className="p-1 bg-gray-200 rounded text-center cursor-move capitalize"
-            >
-              {name}
-            </div>
-          ))}
-        </div>
-        <h2 className="font-bold mt-4">Playlist</h2>
-        <div className="space-y-1">
-          {playlist.map((item, idx) => (
-            <div
-              key={idx}
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={(e) => handleDrop(e, idx)}
-              className="h-8 border border-dashed rounded flex items-center justify-center bg-white bg-opacity-60 text-xs capitalize"
-            >
-              {item ? item.name : `Slot ${idx + 1}`}
-            </div>
-          ))}
-        </div>
-        <div className="mt-4 h-2 bg-gray-300 rounded overflow-hidden">
-          <div
-            className="h-full bg-blue-500"
-            style={{ width: `${totalSteps ? (currentStep / totalSteps) * 100 : 0}%` }}
-          ></div>
-        </div>
-      </div>
+      <CameraPlaylist
+        angles={angles}
+        playlist={playlist}
+        handleDragStart={handleDragStart}
+        handleDrop={handleDrop}
+        currentStep={currentStep}
+        totalSteps={totalSteps}
+      />
       <div className="flex-1 relative">
-        <div className="absolute inset-0" ref={mountRef}></div>
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex space-x-2 z-10">
-          <button
-            onClick={toggleAudio}
-            className="px-3 py-1 text-sm bg-white bg-opacity-80 rounded shadow hover:bg-opacity-100"
-          >
-            {audioOn ? 'Stop Sound' : 'Play Sound'}
-          </button>
-          <button
-            onClick={playPlaylist}
-            disabled={playing}
-            className="px-3 py-1 text-sm bg-white bg-opacity-80 rounded shadow hover:bg-opacity-100 disabled:opacity-50"
-          >
-            {playing ? 'Playing...' : 'Play Camera Playlist'}
-          </button>
-        </div>
+        <ThreeScene cameraRef={cameraRef} controlsRef={controlsRef} />
+        <Controls
+          audioOn={audioOn}
+          toggleAudio={toggleAudio}
+          playing={playing}
+          playPlaylist={playPlaylist}
+        />
       </div>
-      <div className="absolute top-4 right-4 space-y-2 z-20">
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            className="px-2 py-1 bg-black bg-opacity-80 text-white text-sm rounded"
-          >
-            {t.message}
-          </div>
-        ))}
-      </div>
+      <Toasts toasts={toasts} />
     </div>
   )
 }

--- a/frontend/src/components/CameraPlaylist.jsx
+++ b/frontend/src/components/CameraPlaylist.jsx
@@ -1,0 +1,40 @@
+function CameraPlaylist({ angles, playlist, handleDragStart, handleDrop, currentStep, totalSteps }) {
+  return (
+    <div className="w-64 p-2 bg-white bg-opacity-70 overflow-y-auto space-y-2">
+      <h2 className="font-bold">Camera Angles</h2>
+      <div className="space-y-1">
+        {Object.keys(angles).map((name) => (
+          <div
+            key={name}
+            draggable
+            onDragStart={(e) => handleDragStart(e, name)}
+            className="p-1 bg-gray-200 rounded text-center cursor-move capitalize"
+          >
+            {name}
+          </div>
+        ))}
+      </div>
+      <h2 className="font-bold mt-4">Playlist</h2>
+      <div className="space-y-1">
+        {playlist.map((item, idx) => (
+          <div
+            key={idx}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => handleDrop(e, idx)}
+            className="h-8 border border-dashed rounded flex items-center justify-center bg-white bg-opacity-60 text-xs capitalize"
+          >
+            {item ? item.name : `Slot ${idx + 1}`}
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 h-2 bg-gray-300 rounded overflow-hidden">
+        <div
+          className="h-full bg-blue-500"
+          style={{ width: `${totalSteps ? (currentStep / totalSteps) * 100 : 0}%` }}
+        ></div>
+      </div>
+    </div>
+  )
+}
+
+export default CameraPlaylist

--- a/frontend/src/components/Controls.jsx
+++ b/frontend/src/components/Controls.jsx
@@ -1,0 +1,21 @@
+function Controls({ audioOn, toggleAudio, playing, playPlaylist }) {
+  return (
+    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex space-x-2 z-10">
+      <button
+        onClick={toggleAudio}
+        className="px-3 py-1 text-sm bg-white bg-opacity-80 rounded shadow hover:bg-opacity-100"
+      >
+        {audioOn ? 'Stop Sound' : 'Play Sound'}
+      </button>
+      <button
+        onClick={playPlaylist}
+        disabled={playing}
+        className="px-3 py-1 text-sm bg-white bg-opacity-80 rounded shadow hover:bg-opacity-100 disabled:opacity-50"
+      >
+        {playing ? 'Playing...' : 'Play Camera Playlist'}
+      </button>
+    </div>
+  )
+}
+
+export default Controls

--- a/frontend/src/components/ThreeScene.jsx
+++ b/frontend/src/components/ThreeScene.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+
+/* eslint-disable react-hooks/exhaustive-deps */
+
+function ThreeScene({ cameraRef, controlsRef }) {
+  const mountRef = useRef(null)
+
+  useEffect(() => {
+    const mount = mountRef.current
+    const width = mount.clientWidth
+    const height = mount.clientHeight
+
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000)
+    camera.position.set(0, 1.5, 5)
+    cameraRef.current = camera
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    renderer.setSize(width, height)
+    mount.appendChild(renderer.domElement)
+
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.enableDamping = true
+    controlsRef.current = controls
+
+    const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1)
+    scene.add(light)
+
+    const loader = new GLTFLoader()
+    let mixer
+
+    loader.load('/Chicken.glb', (gltf) => {
+      const model = gltf.scene
+      scene.add(model)
+
+      if (gltf.animations && gltf.animations.length) {
+        mixer = new THREE.AnimationMixer(model)
+        const action = mixer.clipAction(gltf.animations[0])
+        action.play()
+      }
+      animate()
+    })
+
+    const clock = new THREE.Clock()
+
+    function animate() {
+      requestAnimationFrame(animate)
+      if (mixer) mixer.update(clock.getDelta())
+      controls.update()
+      renderer.render(scene, camera)
+    }
+
+    return () => {
+      renderer.dispose()
+      mount.removeChild(renderer.domElement)
+    }
+  }, [])
+
+  return <div className="absolute inset-0" ref={mountRef}></div>
+}
+
+export default ThreeScene

--- a/frontend/src/components/Toasts.jsx
+++ b/frontend/src/components/Toasts.jsx
@@ -1,0 +1,16 @@
+function Toasts({ toasts }) {
+  return (
+    <div className="absolute top-4 right-4 space-y-2 z-20">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className="px-2 py-1 bg-black bg-opacity-80 text-white text-sm rounded"
+        >
+          {t.message}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default Toasts

--- a/frontend/src/utils/tween.js
+++ b/frontend/src/utils/tween.js
@@ -1,0 +1,27 @@
+import * as THREE from 'three'
+
+export function tweenTo(camera, controls, pos, duration = 1000) {
+  return new Promise((resolve) => {
+    if (!camera || !controls) {
+      resolve()
+      return
+    }
+    const start = camera.position.clone()
+    const target = new THREE.Vector3(pos.x, pos.y, pos.z)
+    let startTime
+    function step(time) {
+      if (!startTime) startTime = time
+      const t = (time - startTime) / duration
+      if (t < 1) {
+        camera.position.lerpVectors(start, target, t)
+        controls.update()
+        requestAnimationFrame(step)
+      } else {
+        camera.position.copy(target)
+        controls.update()
+        resolve()
+      }
+    }
+    requestAnimationFrame(step)
+  })
+}


### PR DESCRIPTION
## Summary
- move three.js scene setup to `ThreeScene` component
- create `CameraPlaylist`, `Controls`, and `Toasts` components
- extract `tweenTo` util
- refactor `App` to use the new components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68804ef6cb44832996fb4b9a1c632c5b